### PR TITLE
[Offline] Bug fix. Cached files now serving in offline too

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -43,7 +43,7 @@ self.addEventListener('fetch', event => {
 	if (url.hostname === self.location.hostname && url.port !== self.location.port) return;
 
 	// always serve static files and bundler-generated assets from cache
-	if (url.host === self.location.host && cached.has(url.pathname.slice(1)) {
+	if (url.host === self.location.host && cached.has(event.request) {
 		event.respondWith(caches.match(event.request));
 		return;
 	}

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -43,7 +43,7 @@ self.addEventListener('fetch', event => {
 	if (url.hostname === self.location.hostname && url.port !== self.location.port) return;
 
 	// always serve static files and bundler-generated assets from cache
-	if (url.host === self.location.host && cached.has(url.pathname)) {
+	if (url.host === self.location.host && cached.has(url.pathname.slice(1)) {
 		event.respondWith(caches.match(event.request));
 		return;
 	}


### PR DESCRIPTION
Please read below for explanation.
```js
const files = [
    // ...
    "favicon.png",
    // ...
];

const to_cache = shell.concat(files).filter(n => n !== '.DS_Store');
const cached = new Set(to_cache);

self.addEventListener('fetch', event => {
    // ...

    /*
     * READ THIS
     * We cannot pass this condition, cause of: url.pathname === "/favicon.png"
     * this cannot match: cached.has("/favicon.png") <= (cached.has(url.pathname))
     * but this matches: cached.has("favicon.png") <= cached.has(url.pathname.slice(1))
     */
    if (url.host === self.location.host && cached.has(url.pathname)) {
        // serving...
    }

    // ...
});
```