### PR TITLE
Make the headline a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# hn.svelte.dev
+# [hn.svelte.dev](https://hn.svelte.dev)
 
 Hacker News clone built with [Svelte](https://svelte.dev) and [Sapper](https://sapper.svelte.dev).


### PR DESCRIPTION
The project was missing a noticeable link to the live version.