### PR TITLE
Disallow all search engines from crawling website

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
- Add robots.txt with rules to not allow crawling by any user-agent

I often find when searching for Svelte related libraries that I get false results coming from the Svelte Hacker News clone. 

As an example, I would look for possible implementations of ["Carlo"](https://github.com/GoogleChromeLabs/carlo) with "Svelte". But instead, get an item from HN that is unrelated https://hn.svelte.dev/item/18247352

I feel that we should disable the crawling as the website has no real need to draw users to it and the source of truth (Github Repo) is linked to and searchable enough.