### PR TITLE
Add prefers-reduced-motion query for background-color transition

### DIFF
--- a/static/global.css
+++ b/static/global.css
@@ -20,6 +20,12 @@ body {
 	transition: background-color 0.6s;
 }
 
+@media (prefers-reduced-motion: reduce) {
+	body {
+		transition: none;
+	}
+}
+
 h1, h2, h3, h4, h5, h6 {
 	margin: 0 0 0.5em 0;
 	font-weight: 400;


### PR DESCRIPTION
Disable `body` background-color transition for people who may find the colour inversion animation uncomfortable.