### PR TITLE
Make package.json build script consistent with other examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm run sapper
+    - run: npm run build
       env:
         CI: true

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm run dev -- --open
 To build a production version...
 
 ```
-npm run sapper
+npm run build
 ```
 
 ...then follow the instructions to serve the app.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "sapper dev",
-    "sapper": "sapper build --legacy",
+    "build": "sapper build --legacy",
     "start": "node __sapper__/build",
     "deploy": "make deploy",
     "cy:run": "cypress run",


### PR DESCRIPTION
I think it's kind of weird that it's called `sapper` today. Calling it `build` would be more inline with [the template](https://github.com/sveltejs/sapper-template/blob/master/package_template.json) and [RealWorld](https://github.com/sveltejs/realworld/blob/master/package.json) examples.