### PR TITLE
Fix building the app with @sveltejs/kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "@snowpack/plugin-svelte": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@snowpack/plugin-svelte/-/plugin-svelte-2.2.0.tgz",
+      "integrity": "sha512-eChNIuH9Lfo0eP6faBsTGxfRhJcpaC17WK9e2bazWuZ5gbsKWBmMWqBPrYVX8UqUjtlwZjTjPICqCPuzWpwHjg==",
       "dev": true,
       "requires": {
         "rollup-plugin-svelte": "^6.0.0",
@@ -1473,9 +1475,10 @@
     },
     "@sveltejs/adapter-netlify": {
       "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-0.0.7.tgz",
+      "integrity": "sha512-3cXq3tPby8yxtkGkAzafxcszkjclQKlqnvGUN7mhickOWFwEqA94o3stEipQHFhvwFQFtzRBfcBn/K6eYhLIEA==",
       "dev": true,
       "requires": {
-        "kleur": "^4.1.3",
         "tiny-glob": "^0.2.6",
         "toml": "^3.0.0"
       },
@@ -2594,8 +2597,7 @@
         "kleur": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.3.tgz",
-          "integrity": "sha512-H1tr8QP2PxFTNwAFM74Mui2b6ovcY9FoxJefgrwxY+OCJcq01k5nvhf4M/KnizzrJvLRap5STUy7dgDV35iUBw==",
-          "dev": true
+          "integrity": "sha512-H1tr8QP2PxFTNwAFM74Mui2b6ovcY9FoxJefgrwxY+OCJcq01k5nvhf4M/KnizzrJvLRap5STUy7dgDV35iUBw=="
         },
         "levn": {
           "version": "0.4.1",
@@ -3294,19 +3296,30 @@
       "integrity": "sha512-Eb21pLObVBQnbgDdhDVdLuisWL97ohCm3B8C1VGizCJAPJ6wU0uLwjAGNJQcsZW+P07ZA2gVTEd/ivKXknYiWg==",
       "dev": true
     },
-    "@sveltejs/kit": {
-      "version": "0.0.11",
+    "@sveltejs/app-utils": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/app-utils/-/app-utils-0.0.3.tgz",
+      "integrity": "sha512-u7O1llpwluv5IOqzGZos43tTapLwsKDT56RNC7ln/sgKfeTYIt+xelF9g0uWNGFKSR0vrtXiR/Qc05HwFPOExg==",
       "dev": true,
       "requires": {
-        "@sveltejs/app-utils": "0.0.5",
+        "mime": "^2.4.6"
+      }
+    },
+    "@sveltejs/kit": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-0.0.11.tgz",
+      "integrity": "sha512-1+6CRSecsq1Y7zabKVBhqANr6lumu5v387q3jsXpKTyJ/zOHkxgDkMx3B/gB/fS9799PtD1+cb2lGb+q9ZOmNA==",
+      "dev": true,
+      "requires": {
+        "@sveltejs/app-utils": "0.0.3",
         "cheap-watch": "^1.0.2",
         "find-cache-dir": "^3.3.1",
         "http-proxy": "^1.18.1",
-        "rollup": "^2.30.0",
+        "rollup": "^2.28.2",
         "rollup-dependency-tree": "0.0.14",
         "rollup-plugin-css-chunks": "^1.2.8",
         "rollup-plugin-terser": "^7.0.2",
-        "sade": "^1.7.4",
+        "sade": "^1.7.3",
         "snowpack": "^2.14.1-pre.0"
       },
       "dependencies": {
@@ -3479,15 +3492,6 @@
           "requires": {
             "execa": "^4.0.3",
             "npm-run-path": "^4.0.1"
-          }
-        },
-        "@sveltejs/app-utils": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/@sveltejs/app-utils/-/app-utils-0.0.5.tgz",
-          "integrity": "sha512-QDJUB2u0XlotgyYYTDi0saP4zR33lgqUSxNOLccRD0LlhYevF6r89BNgPzhhlvGfHQA9EdFyzKPn020Qd008Bw==",
-          "dev": true,
-          "requires": {
-            "mime": "^2.4.6"
           }
         },
         "@types/estree": {
@@ -4328,11 +4332,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-2.1.1.tgz",
           "integrity": "sha512-Z9W+J5zeYY7lb9AQml90o6+HmP6qfs3PfM460eoD+EudNbM9wbnUQ/7Ko2S2SqR4EaaPIb6eI56qG2/KB7kByA=="
-        },
-        "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "mime-db": {
           "version": "1.45.0",
@@ -5318,6 +5317,12 @@
         "iconv-lite": "^0.6.2"
       }
     },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
@@ -5326,20 +5331,63 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
+    "mime": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
+    "require-relative": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
+      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
+      "dev": true
+    },
+    "rollup-plugin-svelte": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-6.1.0.tgz",
+      "integrity": "sha512-TX1nIZSD6ePiSdYIEfpkvR7lLnP1nsSycCVz+vXbm5d5kIe5WMldo6fwcL/T8KPjc42XDgLaRcS74BorpQvpiA==",
+      "dev": true,
+      "requires": {
+        "require-relative": "^0.8.7",
+        "rollup-pluginutils": "^2.8.2",
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
     "svelte": {
       "version": "3.29.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.29.0.tgz",
       "integrity": "sha512-f+A65eyOQ5ujETLy+igNXtlr6AEjAQLYd1yJE1VwNiXMQO5Z/Vmiy3rL+zblV/9jd7rtTTWqO1IcuXsP2Qv0OA==",
+      "dev": true
+    },
+    "svelte-hmr": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.11.1.tgz",
+      "integrity": "sha512-ecW9G/Pp7+RXXFvoWcF1WQsdajgigtdFH6qe25kMggmidvqTrzThkfELfR8cgnWng6eNVV4Y70vvb4MI/3N7OQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "@sveltejs/adapter-netlify": "^0.0.7",
     "@sveltejs/adapter-node": "0.0.3",
     "@sveltejs/kit": "^0.0.11",
-    "svelte": "^3.29.0"
+    "rollup-plugin-svelte": "^6.1.0",
+    "svelte": "^3.29.0",
+    "svelte-hmr": "^0.11.1"
   },
   "dependencies": {
     "encoding": "^0.1.13",


### PR DESCRIPTION
I wanted to check out @sveltejs/kit after Rich's demo. After cloning the repo both `npm run dev` and `npm run build` gave me the following error:


> Error: Cannot find module 'rollup-plugin-svelte'

And after adding that dependency, I got the same error for `svelte-hmr`.

Simply adding these packages as dev dependencies fixed the issue.